### PR TITLE
Add local docker-compose file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,7 +27,7 @@ coverage/
 .dockerignore
 Dockerfile
 docker-compose.yml
-docker-base.yml
+docker-base*.yml
 
 # Environment variables
 .env

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Docker Compose Configuration
+DOCKER_BASE_FILE=docker-base.local.yml
+
 # AMQP Service Configuration
 AMQP_PORT='5672'
 AMQP_DASHBOARD_PORT='15672'

--- a/docker-base.local.yml
+++ b/docker-base.local.yml
@@ -5,6 +5,8 @@ services:
     depends_on:
       - amqp-service
       - mysql-service
+    env_file:
+      - .env
     environment:
       - DB_HOST=http://mysql-service
       - DB_PASSWORD=${MYSQL_ROOT_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_CLOCK_DB}
     extends:
-      file: docker-base.yml
+      file: ${DOCKER_BASE_FILE:?}
       service: base-service
 
   mail-service:
@@ -24,7 +24,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_MAIL_DB}
     extends:
-      file: docker-base.yml
+      file: ${DOCKER_BASE_FILE:?}
       service: base-service
 
   mysql-service:
@@ -46,7 +46,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_READ_DB}
     extends:
-      file: docker-base.yml
+      file: ${DOCKER_BASE_FILE:?}
       service: base-service
     ports:
       - '${READ_SERVICE_PORT}:3000'
@@ -58,7 +58,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_SCORE_DB}
     extends:
-      file: docker-base.yml
+      file: ${DOCKER_BASE_FILE:?}
       service: base-service
 
   submission-service:
@@ -68,7 +68,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_SUBMISSION_DB}
     extends:
-      file: docker-base.yml
+      file: ${DOCKER_BASE_FILE:?}
       service: base-service
 
   target-service:
@@ -78,7 +78,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_TARGET_DB}
     extends:
-      file: docker-base.yml
+      file: ${DOCKER_BASE_FILE:?}
       service: base-service
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_CLOCK_DB}
     extends:
-      file: ${DOCKER_BASE_FILE:?}
+      file: ${DOCKER_BASE_FILE:-docker-base.yml}
       service: base-service
 
   mail-service:
@@ -24,7 +24,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_MAIL_DB}
     extends:
-      file: ${DOCKER_BASE_FILE:?}
+      file: ${DOCKER_BASE_FILE:-docker-base.yml}
       service: base-service
 
   mysql-service:
@@ -46,7 +46,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_READ_DB}
     extends:
-      file: ${DOCKER_BASE_FILE:?}
+      file: ${DOCKER_BASE_FILE:-docker-base.yml}
       service: base-service
     ports:
       - '${READ_SERVICE_PORT}:3000'
@@ -58,7 +58,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_SCORE_DB}
     extends:
-      file: ${DOCKER_BASE_FILE:?}
+      file: ${DOCKER_BASE_FILE:-docker-base.yml}
       service: base-service
 
   submission-service:
@@ -68,7 +68,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_SUBMISSION_DB}
     extends:
-      file: ${DOCKER_BASE_FILE:?}
+      file: ${DOCKER_BASE_FILE:-docker-base.yml}
       service: base-service
 
   target-service:
@@ -78,7 +78,7 @@ services:
     environment:
       - DB_NAME=${MYSQL_TARGET_DB}
     extends:
-      file: ${DOCKER_BASE_FILE:?}
+      file: ${DOCKER_BASE_FILE:-docker-base.yml}
       service: base-service
 
 networks:


### PR DESCRIPTION
Bunnyshell gebruikt zijn interne omgevingsvariabelen. Het verwijderen van het .env bestand in de productie docker-compose lost het .env gebruik probleem op aan de kant van Bunnyshell.

Link naar issue: https://github.com/LarsDevans/eindopdracht.devops-webs5/issues/3 (de issue niet koppelen hieraan, omdat die uit meerdere DevOps taken bestaat)