### PR TITLE
Update RabbitMQ queue name configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,19 +2,15 @@
 DOCKER_BASE_FILE=docker-base.local.yml
 
 # RabbitMQ Service Configuration
-RABBITMQ_PORT='5672'
-RABBITMQ_DASHBOARD_PORT='15672'
-RABBITMQ_URI='amqp://rabbitmq-service'
+RMQ_PORT='5672'
+RMQ_DASHBOARD_PORT='15672'
+RMQ_URI='amqp://rabbitmq-service'
 
 # RabbitMQ Queue Configuration
-RABBITMQ_RIVAL_CREATED_QUEUE='rival_created'
-RABBITMQ_RIVAL_REVOKED_QUEUE='rival_revoked'
-RABBITMQ_RIVAL_GRADED_QUEUE='rival_graded'
-RABBITMQ_RIVAL_GRADE_FAILED_QUEUE='rival_grade_failed'
-RABBITMQ_RIVAL_UPLOAD_FAILED_QUEUE='rival_upload_failed'
-RABBITMQ_TARGET_CREATED_QUEUE='target_created'
-RABBITMQ_TARGET_COMPLETED_QUEUE='target_completed'
-RABBITMQ_TARGET_REVOKED_QUEUE='target_revoked'
+RMQ_CLOCK_QUEUE='clock_queue'
+RMQ_SCORE_QUEUE='score_queue'
+RMQ_SUBMISSION_QUEUE='submission_queue'
+RMQ_TARGET_QUEUE='target_queue'
 
 # Database Configuration for MySQL
 MYSQL_CLOCK_DB='clock_db'

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ RMQ_SCORE_QUEUE='score_queue'
 RMQ_SUBMISSION_QUEUE='submission_queue'
 RMQ_TARGET_QUEUE='target_queue'
 
+# RabbitMQ Queue Configuration
+RMQ_TQ_TARGET_CREATED_EVENT='target_created'
+
 # Database Configuration for MySQL
 MYSQL_CLOCK_DB='clock_db'
 MYSQL_MAIL_DB='mail_db'

--- a/apps/clock-service/src/main.ts
+++ b/apps/clock-service/src/main.ts
@@ -2,24 +2,10 @@ import { NestFactory } from '@nestjs/core';
 import { ClockServiceModule } from './clock-service.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { Transport } from '@nestjs/microservices';
 
 async function bootstrap() {
   const app =
     await NestFactory.create<NestExpressApplication>(ClockServiceModule);
-
-  const queues = [process.env.RABBITMQ_TARGET_COMPLETED_QUEUE];
-
-  queues.forEach((queue) => {
-    app.connectMicroservice({
-      transport: Transport.RMQ,
-      options: {
-        urls: [`${process.env.RABBITMQ_URI}:${process.env.RABBITMQ_PORT}`],
-        queue,
-        noAck: false,
-      },
-    });
-  });
 
   // Swagger / OA docs
   const config = new DocumentBuilder()

--- a/apps/score-service/src/main.ts
+++ b/apps/score-service/src/main.ts
@@ -2,27 +2,10 @@ import { NestFactory } from '@nestjs/core';
 import { ScoreServiceModule } from './score-service.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { Transport } from '@nestjs/microservices';
 
 async function bootstrap() {
   const app =
     await NestFactory.create<NestExpressApplication>(ScoreServiceModule);
-
-  const queues = [
-    process.env.RABBITMQ_RIVAL_GRADED_QUEUE,
-    process.env.RABBITMQ_RIVAL_GRADE_FAILED_QUEUE,
-  ];
-
-  queues.forEach((queue) => {
-    app.connectMicroservice({
-      transport: Transport.RMQ,
-      options: {
-        urls: [`${process.env.RABBITMQ_URI}:${process.env.RABBITMQ_PORT}`],
-        queue,
-        noAck: false,
-      },
-    });
-  });
 
   // Swagger / OA docs
   const config = new DocumentBuilder()

--- a/apps/submission-service/src/main.ts
+++ b/apps/submission-service/src/main.ts
@@ -2,29 +2,11 @@ import { NestFactory } from '@nestjs/core';
 import { SubmissionServiceModule } from './submission-service.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { Transport } from '@nestjs/microservices';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(
     SubmissionServiceModule,
   );
-
-  const queues = [
-    process.env.RABBITMQ_RIVAL_CREATED_QUEUE,
-    process.env.RABBITMQ_RIVAL_REVOKED_QUEUE,
-    process.env.RABBITMQ_RIVAL_UPLOAD_FAILED_QUEUE,
-  ];
-
-  queues.forEach((queue) => {
-    app.connectMicroservice({
-      transport: Transport.RMQ,
-      options: {
-        urls: [`${process.env.RABBITMQ_URI}:${process.env.RABBITMQ_PORT}`],
-        queue,
-        noAck: false,
-      },
-    });
-  });
 
   // Swagger / OA docs
   const config = new DocumentBuilder()

--- a/apps/target-service/src/main.ts
+++ b/apps/target-service/src/main.ts
@@ -2,27 +2,10 @@ import { NestFactory } from '@nestjs/core';
 import { TargetServiceModule } from './target-service.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { Transport } from '@nestjs/microservices';
 
 async function bootstrap() {
   const app =
     await NestFactory.create<NestExpressApplication>(TargetServiceModule);
-
-  const queues = [
-    process.env.RABBITMQ_TARGET_CREATED_QUEUE,
-    process.env.RABBITMQ_TARGET_REVOKED_QUEUE,
-  ];
-
-  queues.forEach((queue) => {
-    app.connectMicroservice({
-      transport: Transport.RMQ,
-      options: {
-        urls: [`${process.env.RABBITMQ_URI}:${process.env.RABBITMQ_PORT}`],
-        queue,
-        noAck: false,
-      },
-    });
-  });
 
   // Swagger / OA docs
   const config = new DocumentBuilder()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   rabbitmq-service:
     image: rabbitmq:4-management-alpine
     ports:
-      - '${RABBITMQ_PORT}:5672'
-      - '${RABBITMQ_DASHBOARD_PORT}:15672'
+      - '${RMQ_PORT}:5672'
+      - '${RMQ_DASHBOARD_PORT}:15672'
     networks:
       - snapnet
 

--- a/libs/rmq/src/rmq.module.ts
+++ b/libs/rmq/src/rmq.module.ts
@@ -23,7 +23,7 @@ export class RmqModule {
               transport: Transport.RMQ,
               options: {
                 urls: [
-                  `${configService.get<string>('RABBITMQ_URI')}:${configService.get<string>('RABBITMQ_PORT')}`,
+                  `${configService.get<string>('RMQ_URI')}:${configService.get<string>('RMQ_PORT')}`,
                 ],
                 queue: configService.get<string>(`RABBITMQ_${name}_QUEUE`),
               },

--- a/libs/rmq/src/rmq.service.ts
+++ b/libs/rmq/src/rmq.service.ts
@@ -11,7 +11,7 @@ export class RmqService {
       transport: Transport.RMQ,
       options: {
         urls: [
-          `${this.configService.get<string>('RABBITMQ_URI')}:${this.configService.get<string>('RABBITMQ_PORT')}`,
+          `${this.configService.get<string>('RMQ_URI')}:${this.configService.get<string>('RMQ_PORT')}`,
         ],
         queue: this.configService.get<string>(`RABBITMQ_${queue}_QUEUE`),
         noAck,


### PR DESCRIPTION
Mocht je een event willen gebruiken, voeg deze dan de bestanden `.env` en `.env.example` toe. De syntax die gebruikt wordt is als volgt:

**RMQ_XX_YY_EVENT**
XX = De eerste letter van de queue naam + Q van 'queue'. Dus bijvoorbeeld: _TQ_ is 'TARGET QUEUE'
YY = De event naam + EVENT. Dus bijvoorbeeld _TARGET_CREATED_EVENT_

Het voorbeeld resulteert in de volgende waarde: _RMQ_TQ_TARGET_CREATED_EVENT_